### PR TITLE
Add deferred capturing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(artec_scanner_robotraconteur_driver
 	src/artec_scanning_procedure.cpp
 	src/artec_scanner_algorithm_util.cpp
 	src/artec_scanner_algorithm.cpp
+	src/artec_scanning_deferred.cpp
     ${RR_THUNK_HDRS}
 	${RR_THUNK_SRCS}
 )

--- a/include/artec_scanner_impl.h
+++ b/include/artec_scanner_impl.h
@@ -85,9 +85,17 @@ namespace artec_scanner_robotraconteur_driver
 
             void set_save_path(boost::optional<boost::filesystem::path> save_path);
 
-            RR_INTRUSIVE_PTR<com::robotraconteur::geometry::shapes::Mesh > capture(RobotRaconteur::rr_bool with_texture) override;
+            com::robotraconteur::geometry::shapes::MeshPtr capture(RobotRaconteur::rr_bool with_texture) override;
 
             RobotRaconteur::RRArrayPtr<uint8_t> capture_stl() override;
+
+            int32_t capture_deferred(RobotRaconteur::rr_bool with_texture) override;
+
+            com::robotraconteur::geometry::shapes::MeshPtr getf_deferred_capture(int32_t deferred_capture_handle) override;
+
+            RobotRaconteur::RRArrayPtr<uint8_t > getf_deferred_capture_stl(int32_t deferred_capture_handle) override;
+
+            void deferred_capture_free(const RobotRaconteur::RRArrayPtr<int32_t>& deferred_capture_handle) override;
 
             RobotRaconteur::GeneratorPtr<experimental::artec_scanner::ScanningProcedureStatusPtr,void>
                 run_scanning_procedure(const experimental::artec_scanner::ScanningProcedureSettingsPtr& settings) 
@@ -104,6 +112,8 @@ namespace artec_scanner_robotraconteur_driver
 
             RobotRaconteur::GeneratorPtr<experimental::artec_scanner::RunAlgorithmsStatusPtr,void >
                 run_algorithms(int32_t input_model_handle, const RobotRaconteur::RRListPtr<RobotRaconteur::RRValue>& algorithms) override;
+
+            void free_all() override;
 
             virtual ~ArtecScannerImpl();
     };

--- a/include/artec_scanner_impl.h
+++ b/include/artec_scanner_impl.h
@@ -59,6 +59,17 @@ namespace artec_scanner_robotraconteur_driver
 
     class ScanningProcedure;
     class RunAlgorithms;
+    class DeferredCapturePrepare;
+
+    struct RRDeferredCapture
+    {
+        int32_t handle = -1;
+        artec::sdk::base::TRef<artec::sdk::capturing::IFrame> frame;
+        com::robotraconteur::geometry::shapes::MeshPtr mesh;
+        RobotRaconteur::RRArrayPtr<uint8_t> mesh_stl_bytes;
+    };
+
+    using RRDeferredCapturePtr = boost::shared_ptr<RRDeferredCapture>;
     
     class ArtecScannerImpl : public experimental::artec_scanner::ArtecScanner_default_impl, 
         public RR_ENABLE_SHARED_FROM_THIS<ArtecScannerImpl>
@@ -72,14 +83,20 @@ namespace artec_scanner_robotraconteur_driver
                         
             int32_t handle_cnt = 100;
             std::map<int32_t,RRArtecModelPtr> models;
+            std::map<int32_t,RRDeferredCapturePtr> deferred_captures;
 
             boost::mutex this_lock;
 
-            boost::optional<boost::filesystem::path> save_path;            
+            boost::optional<boost::filesystem::path> save_path;
+
+            void deferred_capture_to_iframemesh(const RRDeferredCapturePtr& deferred_capture, artec::sdk::base::IFrameMesh** frame_mesh);
+
+            RRDeferredCapturePtr get_deferred_capture(int32_t deferred_capture_handle);
 
         public:
             friend class ScanningProcedure;
             friend class RunAlgorithms;
+            friend class DeferredCapturePrepare;
 
             void Init(artec::sdk::capturing::IScanner* scanner);
 
@@ -96,6 +113,15 @@ namespace artec_scanner_robotraconteur_driver
             RobotRaconteur::RRArrayPtr<uint8_t > getf_deferred_capture_stl(int32_t deferred_capture_handle) override;
 
             void deferred_capture_free(const RobotRaconteur::RRArrayPtr<int32_t>& deferred_capture_handle) override;
+
+            RobotRaconteur::GeneratorPtr<experimental::artec_scanner::DeferredCapturePrepareStatusPtr,void> 
+                deferred_capture_prepare(const RobotRaconteur::RRArrayPtr<int32_t >& deferred_capture_handles) 
+                override;
+
+            RobotRaconteur::GeneratorPtr<experimental::artec_scanner::DeferredCapturePrepareStatusPtr,void> 
+                deferred_capture_prepare_stl(const RobotRaconteur::RRArrayPtr<int32_t >& deferred_capture_handles)
+                override;
+
 
             RobotRaconteur::GeneratorPtr<experimental::artec_scanner::ScanningProcedureStatusPtr,void>
                 run_scanning_procedure(const experimental::artec_scanner::ScanningProcedureSettingsPtr& settings) 

--- a/include/artec_scanner_impl.h
+++ b/include/artec_scanner_impl.h
@@ -87,7 +87,7 @@ namespace artec_scanner_robotraconteur_driver
 
             RR_INTRUSIVE_PTR<com::robotraconteur::geometry::shapes::Mesh > capture(RobotRaconteur::rr_bool with_texture) override;
 
-            RobotRaconteur::RRArrayPtr<uint8_t> capture_obj(RobotRaconteur::rr_bool with_texture) override;
+            RobotRaconteur::RRArrayPtr<uint8_t> capture_stl() override;
 
             RobotRaconteur::GeneratorPtr<experimental::artec_scanner::ScanningProcedureStatusPtr,void>
                 run_scanning_procedure(const experimental::artec_scanner::ScanningProcedureSettingsPtr& settings) 

--- a/include/artec_scanning_deferred.h
+++ b/include/artec_scanning_deferred.h
@@ -1,0 +1,80 @@
+#include "experimental__artec_scanner.h"
+#include "experimental__artec_scanner_stubskel.h"
+#include <artec/sdk/capturing/IScanner.h>
+#include <artec/sdk/scanning/IScanningProcedure.h>
+#include <artec/sdk/scanning/IScanningProcedureObserver.h>
+#include <artec/sdk/base/TRef.h>
+#include <artec/sdk/base/IJobObserver.h>
+#include <artec/sdk/base/AlgorithmWorkset.h>
+#include "artec_scanner_util.h" 
+
+#include <boost/thread/thread_pool.hpp>
+#include <list>
+
+#pragma once
+
+namespace artec_scanner_robotraconteur_driver
+{
+    class ArtecScannerImpl;
+    struct RRDeferredCapture;
+
+    class DeferredCapturePrepare : public RobotRaconteur::Generator<experimental::artec_scanner::DeferredCapturePrepareStatusPtr,void >,
+        public RR_ENABLE_SHARED_FROM_THIS<DeferredCapturePrepare>
+    {
+        protected:
+            boost::weak_ptr<ArtecScannerImpl> parent;
+            boost::shared_ptr<ArtecScannerImpl> GetParent();
+            boost::mutex& data_lock;
+            boost::mutex this_lock;
+
+            RobotRaconteur::TimerPtr next_timer;
+            std::list<boost::shared_ptr<RRDeferredCapture> > input_data;
+
+            boost::atomic<int32_t> completed_count = 0;
+            boost::atomic<int32_t> failed_count = 0;
+
+            bool mesh = false;
+            bool stl = false;
+            bool started = false;
+            bool closed = false;
+            bool aborted = false;
+            bool completed = false;
+            bool prepare_completed = false;
+            size_t active_thread_count = 0;
+
+            boost::function<void(const experimental::artec_scanner::DeferredCapturePrepareStatusPtr&,
+                const RobotRaconteur::RobotRaconteurExceptionPtr&)> next_handler;
+
+            boost::thread_group thread_pool;
+            artec::sdk::base::TRef<artec::sdk::capturing::IScanner> scanner;
+
+        public:
+
+            DeferredCapturePrepare(boost::shared_ptr<ArtecScannerImpl> parent);
+
+            void Init(std::list<boost::shared_ptr<RRDeferredCapture> >&& input_data, bool mesh, bool stl);
+
+            void AsyncNext(boost::function<void(const experimental::artec_scanner::DeferredCapturePrepareStatusPtr&,
+                const RobotRaconteur::RobotRaconteurExceptionPtr&)> handler, int32_t timeout = RR_TIMEOUT_INFINITE )
+                override;
+
+            void AsyncClose(boost::function<void(const RobotRaconteur::RobotRaconteurExceptionPtr& err)> handler,
+                            int32_t timeout = RR_TIMEOUT_INFINITE) override;
+
+            void AsyncAbort(boost::function<void(const RobotRaconteur::RobotRaconteurExceptionPtr& err)> handler,
+                            int32_t timeout = RR_TIMEOUT_INFINITE) override;
+
+            experimental::artec_scanner::DeferredCapturePrepareStatusPtr Next() override {return nullptr;}
+            void Close() override {}
+            void Abort() override {}
+
+        protected:
+
+            void complete_gen(boost::function<void(const experimental::artec_scanner::DeferredCapturePrepareStatusPtr&,
+                const RobotRaconteur::RobotRaconteurExceptionPtr&)> handler);
+
+            void next_timer_handler(const RobotRaconteur::TimerEvent& evt);
+
+            void prepare();
+    };
+}

--- a/robdef/experimental.artec_scanner.robdef
+++ b/robdef/experimental.artec_scanner.robdef
@@ -211,10 +211,23 @@ struct TexturizationAlgorithm
     field varvalue{string} extended
 end
 
+struct DeferredCapturePrepareStatus
+    field ActionStatusCode action_status
+    field uint32 completed_count
+    field uint32 failed_count
+end
+
 object ArtecScanner
     function Mesh capture(bool with_texture)
     function uint8[] capture_stl()
 
+    function int32 capture_deferred(bool with_texture)
+    function Mesh getf_deferred_capture(int32 deferred_capture_handle)
+    function uint8[] getf_deferred_capture_stl(int32 deferred_capture_handle)
+    function DeferredCapturePrepareStatus{generator} deferred_capture_prepare(int32[] deferred_capture_handles)
+    function DeferredCapturePrepareStatus{generator} deferred_capture_prepare_stl(int32[] deferred_capture_handles)
+    function void deferred_capture_free(int32[] deferred_capture_handles)
+    
     function ScanningProcedureStatus{generator} run_scanning_procedure(ScanningProcedureSettings settings)
 
     function void model_free(int32 model_handle)
@@ -226,6 +239,8 @@ object ArtecScanner
 
     function varvalue initialize_algorithm(int32 input_model_handle, string algorithm)
     function RunAlgorithmsStatus{generator} run_algorithms(int32 input_model_handle, varvalue{list} algorithms)
+
+    function void free_all()
 end
 
 object Model

--- a/robdef/experimental.artec_scanner.robdef
+++ b/robdef/experimental.artec_scanner.robdef
@@ -213,7 +213,7 @@ end
 
 object ArtecScanner
     function Mesh capture(bool with_texture)
-    function uint8[] capture_obj(bool with_texture)
+    function uint8[] capture_stl()
 
     function ScanningProcedureStatus{generator} run_scanning_procedure(ScanningProcedureSettings settings)
 

--- a/src/artec_scanner_impl.cpp
+++ b/src/artec_scanner_impl.cpp
@@ -88,9 +88,26 @@ namespace artec_scanner_robotraconteur_driver
         return rr_mesh;
     }
 
-    RR::RRArrayPtr<uint8_t> ArtecScannerImpl::capture_obj(RR::rr_bool with_texture)
+    RR::RRArrayPtr<uint8_t> ArtecScannerImpl::capture_stl()
     {
-        throw RR::NotImplementedException("");
+        if (this->scanner == nullptr)
+        {
+            RR_ARTEC_LOG_ERROR("Attempt to use scanner when no scanner is available");
+            throw RR::InvalidOperationException("No scanner available");
+        }
+        RR_ARTEC_LOG_INFO("Begin scanner capture");
+        TRef<asdk::IFrame> frame;
+        TRef<asdk::IFrameMesh> mesh;
+        frame = nullptr;
+        mesh = nullptr;
+        asdk::ErrorCode ec = asdk::ErrorCode_OK;
+        RR_CALL_ARTEC(scanner->capture( &frame, false), "Error capturing from scanner");
+        
+        RR_CALL_ARTEC(processor->reconstructAndTexturizeMesh( &mesh, frame ), "Error reconstructing mesh");
+        
+        auto stl_bytes = ConvertArtecMeshToStlBytes(mesh);
+        RR_ARTEC_LOG_INFO("Scanner capture complete");
+        return stl_bytes;
     }
 
     RR::GeneratorPtr<rr_artec::ScanningProcedureStatusPtr,void>

--- a/src/artec_scanner_impl.cpp
+++ b/src/artec_scanner_impl.cpp
@@ -22,6 +22,8 @@
 #include "artec_scanner_algorithm_util.h"
 
 #include <boost/filesystem.hpp>
+#include <boost/range/adaptor/map.hpp>
+#include <boost/range/algorithm/copy.hpp>
 
 namespace asdk {
     using namespace artec::sdk::base;
@@ -291,6 +293,46 @@ namespace artec_scanner_robotraconteur_driver
         return gen;
     }
 
+    int32_t ArtecScannerImpl::capture_deferred(RobotRaconteur::rr_bool with_texture)
+    {
+        throw RR::NotImplementedException("Not implemented");
+    }
+
+    com::robotraconteur::geometry::shapes::MeshPtr ArtecScannerImpl::getf_deferred_capture(int32_t deferred_capture_handle)
+    {
+        throw RR::NotImplementedException("Not implemented");
+    }
+
+    RobotRaconteur::RRArrayPtr<uint8_t > ArtecScannerImpl::getf_deferred_capture_stl(int32_t deferred_capture_handle)
+    {
+        throw RR::NotImplementedException("Not implemented");
+    }
+
+    void ArtecScannerImpl::deferred_capture_free(const RobotRaconteur::RRArrayPtr<int32_t>& deferred_capture_handle)
+    {
+        throw RR::NotImplementedException("Not implemented");
+    }
+
+    void ArtecScannerImpl::free_all()
+    {
+        std::vector<int32_t> model_handles;
+        {
+            boost::mutex::scoped_lock lock(this_lock);
+            boost::copy(models | boost::adaptors::map_keys, std::back_inserter(model_handles));
+        }
+
+        for(auto handle : model_handles)
+        {
+            try
+            {
+                model_free(handle);
+            }
+            catch (std::exception& e)
+            {
+                RR_ARTEC_LOG_ERROR("Error freeing model handle: " << e.what());
+            }
+        }
+    }
 
     RRArtecModel::RRArtecModel()
     {

--- a/src/artec_scanner_robotraconteur_driver.cpp
+++ b/src/artec_scanner_robotraconteur_driver.cpp
@@ -36,7 +36,7 @@ int main(int argc, char* argv[])
         ("no-scanner","Do not search for scanner. Only used to process existing scan data");
 
     po::variables_map vm;
-    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::store(po::command_line_parser(argc, argv).options(desc).allow_unregistered().run(), vm);
     po::notify(vm);
 
     if (vm.count("help")) {

--- a/src/artec_scanner_util.cpp
+++ b/src/artec_scanner_util.cpp
@@ -179,7 +179,7 @@ namespace artec_scanner_robotraconteur_driver
     RobotRaconteur::RRArrayPtr<uint8_t> ConvertArtecMeshToStlBytes(artec::sdk::base::IMesh* mesh)
     {
         boost::filesystem::path temp = boost::filesystem::unique_path();
-        RR_CALL_ARTEC(asdk::io::saveStlMeshToFileAscii(temp.c_str(), mesh), "Could not save mesh to stl");
+        RR_CALL_ARTEC(asdk::io::saveStlMeshToFileBinary(temp.c_str(), mesh), "Could not save mesh to stl");
         std::ifstream file(temp.string(), std::ios::binary | std::ios::ate);
         std::streamsize size = file.tellg();
         file.seekg(0, std::ios::beg);

--- a/src/artec_scanning_deferred.cpp
+++ b/src/artec_scanning_deferred.cpp
@@ -1,0 +1,243 @@
+#include "artec_scanning_deferred.h"
+#include "artec_scanner_impl.h"
+#include "artec_scanner_util.h"
+
+#include <artec/sdk/capturing/IScanner.h>
+#include <artec/sdk/capturing/IArrayScannerId.h>
+#include <artec/sdk/capturing/IFrameProcessor.h>
+#include <artec/sdk/capturing/IFrame.h>
+
+namespace asdk {
+    using namespace artec::sdk::base;
+    using namespace artec::sdk::capturing;
+};
+using asdk::TRef;
+
+
+namespace rr_geom = com::robotraconteur::geometry;
+namespace rr_shapes = com::robotraconteur::geometry::shapes;
+namespace rr_image = com::robotraconteur::image;
+namespace rr_action = com::robotraconteur::action;
+namespace RR=RobotRaconteur;
+namespace rr_artec = experimental::artec_scanner;
+
+namespace artec_scanner_robotraconteur_driver
+{
+    DeferredCapturePrepare::DeferredCapturePrepare(boost::shared_ptr<ArtecScannerImpl> parent)
+        : data_lock(parent->this_lock)
+    {
+        this->scanner = parent->scanner;
+        this->parent=parent;
+    }
+
+    void DeferredCapturePrepare::Init(std::list<boost::shared_ptr<RRDeferredCapture> >&& input_data, bool mesh, bool stl)
+    {
+        this->input_data = std::move(input_data);
+        this->mesh = mesh;
+        this->stl = stl;
+    }
+
+    boost::shared_ptr<ArtecScannerImpl> DeferredCapturePrepare::GetParent()
+    {
+        auto p = parent.lock();
+        if (!p) {
+            RR_ARTEC_LOG_ERROR("ArtecScannerImpl parent has been released");
+            throw RR::InvalidOperationException("ArtecScannerImpl parent has been released");
+        }
+        return p;
+    }
+
+    
+    void DeferredCapturePrepare::prepare()
+    {
+        auto this_ = shared_from_this();
+        active_thread_count = boost::thread::hardware_concurrency();
+        for( unsigned i = 0; i < boost::thread::hardware_concurrency(); i++ )
+        {
+            thread_pool.create_thread( [this_]
+            {
+                // Initialize a frame processor 
+                TRef<asdk::IFrameProcessor> processor;
+                if( this_->scanner->createFrameProcessor( &processor ) != asdk::ErrorCode_OK )
+                {
+                    return;
+                }
+                while(true)
+                {
+                    RRDeferredCapturePtr work;
+                    {
+                        boost::mutex::scoped_lock lock(this_->this_lock);
+                        auto e = this_->input_data.begin();
+                        if (e == this_->input_data.end() || this_->closed || this_->aborted)
+                        {
+                            this_->active_thread_count--;
+                            if (this_->active_thread_count == 0)
+                            {
+                                this_->prepare_completed = true;
+                                if (this_->next_handler)
+                                {
+                                    this_->complete_gen(this_->next_handler);
+                                }
+                            }
+                            return;
+                        }
+                        work = *e;
+                        this_->input_data.erase(e);
+                    }
+
+                    if ((!this_->mesh || work->mesh) && (!this_->stl || work->mesh_stl_bytes))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        
+                        TRef<asdk::IFrameProcessor> processor;
+                        if ( this_->scanner->createFrameProcessor( &processor ) != asdk::ErrorCode_OK )
+                        {
+                            return;
+                        }
+                        asdk::TRef<asdk::IFrameMesh> frame_mesh;
+                        RR_CALL_ARTEC(processor->reconstructAndTexturizeMesh(&frame_mesh, work->frame ), "Error reconstructing mesh");
+                        
+                        rr_shapes::MeshPtr rr_mesh;
+                        if (this_->mesh)
+                        {
+                            rr_mesh = ConvertArtecFrameMeshToRR(frame_mesh);
+                        }
+
+                        RR::RRArrayPtr<uint8_t> stl_bytes;
+                        if (this_->stl)
+                        {
+                            stl_bytes = ConvertArtecMeshToStlBytes(frame_mesh);
+                        }
+
+                        {
+                            boost::mutex::scoped_lock work_lock(this_->data_lock);
+                            if (this_->stl)
+                            {
+                                work->mesh_stl_bytes = stl_bytes;
+                            }
+                            if (this_->mesh)
+                            {
+                                work->mesh = rr_mesh;
+                            }
+                        }
+                        this_->completed_count.fetch_add(1, boost::memory_order_relaxed);
+
+                        RR_ARTEC_LOG_INFO("Completed preparing deferred capture handle " << work->handle);
+                    }
+                    catch (RR::RobotRaconteurException& exp)
+                    {
+                        RR_ARTEC_LOG_ERROR("Error preparing deferred frame handle " << work->handle << ": " << exp.what());
+                        this_->failed_count.fetch_add(1, boost::memory_order_relaxed);
+                    }
+                    catch (std::exception& exp)
+                    {
+                        RR_ARTEC_LOG_ERROR("Error preparing deferred frame handle " << work->handle << ": " << exp.what());
+                        this_->failed_count.fetch_add(1, boost::memory_order_relaxed);
+                    }
+                }
+            });
+        }
+    }
+
+    void DeferredCapturePrepare::AsyncNext(boost::function<void(const experimental::artec_scanner::DeferredCapturePrepareStatusPtr&,
+        const RobotRaconteur::RobotRaconteurExceptionPtr&)> handler, int32_t timeout)
+    {
+        boost::mutex::scoped_lock lock(this_lock);
+        if (aborted)
+        {
+            throw RR::OperationAbortedException("Scanning Procedure operation was aborted");
+        }
+        if ((closed && !started) || completed)
+        {
+            throw RR::StopIterationException("");
+        }
+
+        if (!started)
+        {
+            prepare();
+            auto ret = rr_artec::DeferredCapturePrepareStatusPtr(new rr_artec::DeferredCapturePrepareStatus());
+            ret->action_status = rr_action::ActionStatusCode::running;
+            ret->completed_count = completed_count;
+            ret->failed_count = failed_count;
+            RR_ARTEC_LOG_INFO("Started prepare deferred captures")
+            lock.unlock();
+            handler(ret, nullptr);
+            return;
+        }
+
+        if (next_handler)
+        {
+            throw RR::InvalidOperationException("Next call already in progress");
+        }
+
+        if (prepare_completed)
+        {
+            complete_gen(handler);
+            return;
+        }
+
+        next_handler = handler;
+
+        RR_WEAK_PTR<DeferredCapturePrepare> weak_this = shared_from_this();
+        next_timer = RR::RobotRaconteurNode::s()->CreateTimer(boost::posix_time::seconds(5), 
+            [weak_this](const RR::TimerEvent& evt) {
+                auto t = weak_this.lock();
+                if (!t) return;
+                t->next_timer_handler(evt);
+        }, true);
+        next_timer->Start();
+    }
+
+    void DeferredCapturePrepare::AsyncClose(boost::function<void(const RobotRaconteur::RobotRaconteurExceptionPtr& err)> handler,
+                    int32_t timeout)
+    {
+        boost::mutex::scoped_lock lock(this_lock);
+        closed = true;
+        lock.unlock();
+        handler(nullptr);
+    }
+
+    void DeferredCapturePrepare::AsyncAbort(boost::function<void(const RobotRaconteur::RobotRaconteurExceptionPtr& err)> handler,
+                    int32_t timeout)
+    {
+        boost::mutex::scoped_lock lock(this_lock);
+        aborted = true;
+        lock.unlock();
+        handler(nullptr);
+    }
+
+    void DeferredCapturePrepare::complete_gen(boost::function<void(const experimental::artec_scanner::DeferredCapturePrepareStatusPtr&,
+        const RobotRaconteur::RobotRaconteurExceptionPtr&)> handler)
+    {
+        RR_ARTEC_LOG_INFO("Completing prepare deferred captures");
+        
+        completed = true;
+
+        auto ret = rr_artec::DeferredCapturePrepareStatusPtr(new rr_artec::DeferredCapturePrepareStatus());
+        ret->action_status = rr_action::ActionStatusCode::complete;
+        ret->completed_count = completed_count;
+        ret->failed_count = failed_count;
+        handler(ret,nullptr);
+    }
+
+    void DeferredCapturePrepare::next_timer_handler(const RobotRaconteur::TimerEvent& evt)
+    {
+        boost::mutex::scoped_lock lock(this_lock);
+        auto h = next_handler;
+        next_handler.clear();
+        if (h)
+        {
+            auto ret = rr_artec::DeferredCapturePrepareStatusPtr(new rr_artec::DeferredCapturePrepareStatus());
+            ret->action_status = rr_action::ActionStatusCode::running;
+            ret->completed_count = completed_count;
+            ret->failed_count = failed_count;
+            h(ret, nullptr);
+            return;
+        }
+    }
+
+}


### PR DESCRIPTION
The original capture functions used the scanner to capture the image, and immediately ran the processing algorithms to turn the capture into a mesh. Deferred capturing instead captures the raw scan, but does not immediately process the scan. This allows for a much higher capture rate. The deferred_capture_prepare functions will do the processing in parallel, allowing for an order of magnitude improvement in processing speed for the frames.